### PR TITLE
Adding the API tests

### DIFF
--- a/tests/api/loginToCapitalAPIAndGetUserDetails.spec.ts
+++ b/tests/api/loginToCapitalAPIAndGetUserDetails.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+// import { request } from '@playwright/test';
+
+test.describe('Login and User Details API Tests', () => {
+  let token: string;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    const response = await fetch('http://164.92.199.221/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: 'pawel.kur',
+        password: 'P!ms*4P,@7E&a',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const responseData = await response.json();
+    token = responseData['x-api-token'];
+
+    testInfo.token = token;
+    console.log("Here is Token  " + token);
+  });
+
+  test('Get user details with token', async ({}, testInfo) => {
+    const token = testInfo.token;
+
+    console.log("And one more time hereee   " + token);
+
+    const response = await fetch('http://164.92.199.221/me', {
+      method: 'GET',
+      headers: {
+        'x-api-token': token,
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    const responseData = await response.json();
+    console.log(responseData);
+  });
+});


### PR DESCRIPTION
Added :
- two API tests (one is rather before each and saves token)


Note: tried to use "import { request } from '@playwright/test';" for some reason didn't work and temporarily API requests added with built-in JavaScript function `fetch`. ***Later to be changed***.